### PR TITLE
when drawImage a empty C2S context

### DIFF
--- a/canvas2svg.js
+++ b/canvas2svg.js
@@ -1038,17 +1038,21 @@
             //canvas2svg mock canvas context. In the future we may want to clone nodes instead.
             //also I'm currently ignoring dw, dh, sw, sh, sx, sy for a mock context.
             svg = image.getSvg();
-            defs = svg.childNodes[0];
-            while(defs.childNodes.length) {
-                id = defs.childNodes[0].getAttribute("id");
-                this.__ids[id] = id;
-                this.__defs.appendChild(defs.childNodes[0]);
+            if (svg.childNodes && svg.childNodes.length > 1) {
+                defs = svg.childNodes[0];
+                while(defs.childNodes.length) {
+                    id = defs.childNodes[0].getAttribute("id");
+                    this.__ids[id] = id;
+                    this.__defs.appendChild(defs.childNodes[0]);
+                }
+                group = svg.childNodes[1];
+                if (group) {
+                    parent.appendChild(group);
+                    this.__currentElement = group;
+                    this.translate(dx, dy);
+                    this.__currentElement = currentElement;
+                }
             }
-            group = svg.childNodes[1];
-            parent.appendChild(group);
-            this.__currentElement = group;
-            this.translate(dx, dy);
-            this.__currentElement = currentElement;
         } else if(image.nodeName === "CANVAS" || image.nodeName === "IMG") {
             //canvas or image
             svgImage = this.__createElement("image");


### PR DESCRIPTION
Null pointer error will be thrown when ctx.drawImage(ctx) with an empty C2S context with no childNodes.

These code may fix the problem.
